### PR TITLE
Force osy_syde_coder_c.exe to keep high precision in scaling factors

### DIFF
--- a/opensyde_syde_coder_c/libs/osy_core/exports/C_OSCExportDataPool.cpp
+++ b/opensyde_syde_coder_c/libs/osy_core/exports/C_OSCExportDataPool.cpp
@@ -471,7 +471,7 @@ sint32 C_OSCExportDataPool::mh_AddDefinesHeader(C_SCLStringList & orc_Data, cons
             {
                const C_SCLString c_ElementName = rc_List.c_Elements[u16_ElementIndex].c_Name.UpperCase();
                const C_SCLString c_Factor =
-                  C_OSCExportUti::h_FloatToStrCutZeroes(rc_List.c_Elements[u16_ElementIndex].f64_Factor);
+                  C_OSCExportUti::h_FloatToStrCutZeroes(rc_List.c_Elements[u16_ElementIndex].f64_Factor, true);
 
                if ((rc_List.c_Elements[u16_ElementIndex].f64_Factor <= 0.0) || (c_Factor == "0.0"))
                {


### PR DESCRIPTION
The auto generated datapool factors are currently truncated to 6 decimals. This causes unwanted rounding errors.

Setting `oq_MakePrecise` to `true` allows for *up to* 100 decimals to be printed out.