### PR TITLE
Fixed possible buffer overflow.

### DIFF
--- a/opensyde_syde_sup/libs/opensyde_core/kefex_diaglib/tgl_linux/TGLFile.cpp
+++ b/opensyde_syde_sup/libs/opensyde_core/kefex_diaglib/tgl_linux/TGLFile.cpp
@@ -309,7 +309,7 @@ C_SCLString TGL_PACKAGE stw_tgl::TGL_GetExePath(void)
     C_SCLString c_Path = "";
 
     sprintf(acn_Arg, "/proc/%d/exe", getpid());
-    sn_Return = readlink(acn_Arg, acn_Path, BUFSIZ );
+    sn_Return = readlink(acn_Arg, acn_Path, PATH_MAX );
     if (sn_Return > 0)
     {
        //we got a path ...


### PR DESCRIPTION
Wrong buffer size was passed to readlink(), possible buffer overflow on some systems.